### PR TITLE
Fixed so that all commits in the pushed branch are resolved in redmine

### DIFF
--- a/post-receive
+++ b/post-receive
@@ -1,0 +1,25 @@
+#!/bin/sh
+export GIT_DIR
+COMMITS=''
+
+# for each ref that was updated during the push
+while read OLD_REV NEW_REV REF_NAME; do
+  OLD_REV="`git rev-parse $OLD_REV`"
+  NEW_REV="`git rev-parse $NEW_REV`"
+  if expr "$OLD_REV" : '0*$' >/dev/null; then
+    # if the branch was created, add all revisions in the new branch; skip tags
+    if ! expr "$REF_NAME" : 'refs/tags/' >/dev/null; then
+      REF_REV="`git rev-parse $REF_NAME`"
+      REF_NAME="`git name-rev --name-only $REF_REV`"
+      COMMITS="$COMMITS `git rev-list $REF_NAME | git name-rev --stdin | grep -G \($REF_NAME.*\) | awk '{ print $1 }'`"
+    fi
+
+  elif expr "$NEW_REV" : '0*$' >/dev/null; then
+    # don't think branch deletes ever hit a post-receive hook, so we should never get here
+    printf ''
+  else
+    # add any commits in this push
+    COMMITS="$COMMITS `git rev-parse --not --all | grep -v $(git rev-parse $REF_NAME) | git rev-list --reverse --stdin $(git merge-base $OLD_REV $NEW_REV)..$NEW_REV`"
+  fi
+done
+echo $COMMITS | tr ' ' '\n' | python /var/lib/gitredmine/GitRedmineResolver/post-receive-redmine.py --git-dir=$GIT_DIR http://url.to.redmin/ username password

--- a/post-receive-redmine.py
+++ b/post-receive-redmine.py
@@ -37,7 +37,7 @@ regex = re.compile(restring, re.I)
 #   0a3bf385b261cb71e176ef758c37e94639901e2d 9d3a264654c1b26f4111276d42a83a2ac4626106 refs/heads/master
 def commits():
 	for sLine in iter(sys.stdin.readline, ""):
-	  yield sLine.strip().split(" ")
+	  yield sLine.strip()
 
 
 def quotifyString(str):
@@ -101,5 +101,5 @@ if __name__ == "__main__":
 		
 	repo = git.Repo(gitDir)
 	for commit in commits():
-		oldRev, newRev, ref = commit
+		newRev = commit
 		checkCommit(newRev, Issue)


### PR DESCRIPTION
Mainly updated the post-receive shell script.  On post receive, the script only receives one input line for each branch pushed in the format: <old_rev> <new_rev> <ref_name>.  The shell script uses git commands and the  branch information it receives to figure out the new commits in the pushed branch.
- James 
